### PR TITLE
RFC - Require PHP 5.4 for 1.0

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,9 @@
 <?php
 
+if (!version_compare(PHP_VERSION, '5.4', '>'))
+{
+	die('Error - Please use verison 0.4 if you are using 5.3 or earlier.');
+}
 error_reporting(E_ALL);
 @session_start(); // Don't return an error if session already started
 require_once realpath(__DIR__ . '/includes/index.php');


### PR DESCRIPTION
Please note: This RFC also includes #16.

This is a Request For Comments showing the roadmap for version 1.0.

Let me just put this bluntly, it is difficult to develop for PHP 5.3.  It is necessary to write more lines of code than needed just to accomplish the simplest of tasks, like getting an item out of an explode().

Here is my roadmap for this problem:
Now: Drop support for PHP 5.4 in 1.x, with the understanding that we will provide support for PHP 5.3 in an alternate branch for 0.4.
Nearing release (most likely at RC's): Branch RC to RC-LTS and change anything non-backwards compatible to a backwards-compatible version (if not possible, drop the feature)
At release: Release both 1.0 and 0.4 simultaneously, recommending 1.0 for anyone with PHP 5.4+.
After PHP 5.3 support is discontinued (July 1): No new features for 0.x branch, but bug fixes until an RFC decides otherwise (once no one uses it anymore).
